### PR TITLE
Heroku pg config

### DIFF
--- a/data/seeds/004-foods.js
+++ b/data/seeds/004-foods.js
@@ -60,13 +60,13 @@ exports.seed = function(knex) {
           calcium_daily_pct: 0
         },
         {
-          fatsecret_food_id: 1641,
-          serving_id: 5034,
-          food_name: "chicken breast",
+          fatsecret_food_id: 4891,
+          serving_id: 17336,
+          food_name: "pizza with meat and veggies",
           serving_desc: "one",
           metric_serving_amt: 1,
           metric_serving_unit: "one",
-          retrieved_at: new Date(new Date() - 1000 * 60 * 60 * 20),
+          retrieved_at: new Date(new Date() - 1000 * 60 * 60 * 23),
           serving_url:
             "https://www.fatsecret.com/calories-nutrition/generic/pizza-cheese?portionid=17170&portionamount=1.000", // not actually the correct url. just there to make sure the field works.
           calories_kcal: 66,
@@ -92,7 +92,7 @@ exports.seed = function(knex) {
           serving_desc: "1oz boneless",
           metric_serving_amt: 1,
           metric_serving_unit: "one",
-          retrieved_at: new Date(new Date() - 1000 * 60 * 60 * 28),
+          retrieved_at: new Date(new Date() - 1000 * 60 * 60 * 23),
           serving_url:
             "https://www.fatsecret.com/calories-nutrition/generic/pizza-cheese?portionid=17170&portionamount=1.000", // not actually the correct url. just there to make sure the field works.
           calories_kcal: 66,
@@ -218,15 +218,15 @@ exports.seed = function(knex) {
         {
           fatsecret_food_id: 5735,
           food_name: "Roasted Potato",
-          serving_desc: "1 small (1-3/4\\\" to 2-1/4\\\" dia, raw)",
-          metric_serving_amt: 110.000,
+          serving_desc: '1 small (1-3/4\\" to 2-1/4\\" dia, raw)',
+          metric_serving_amt: 110.0,
           metric_serving_unit: "g",
           retrieved_at: knex.fn.now(6),
           serving_id: 21131,
           calories_kcal: 164,
           fat_g: 0.82,
-          trans_fat_g: 7.70,
-          saturated_fat_g: 0.990,
+          trans_fat_g: 7.7,
+          saturated_fat_g: 0.99,
           monounsaturated_fat_g: 2.562,
           polyunsaturated_fat_g: 3.786,
           protein_g: 2.55,

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,24 +1,9 @@
 require("dotenv").config();
-// this is the draft knexfile created and shared by Will Ediger
 
 const dbConnection = process.env.DATABASE_URL;
 
 module.exports = {
-  production: { //not set up yet
-    client: "pg",
-    connection: "",
-    pool: {
-      min: 2,
-      max: 10
-    },
-    migrations: {
-      directory: "./data/migrations"
-    },
-    seeds: {
-      directory: "./data/seeds"
-    }
-  },
-  development: { //pointing to our local postgres db
+  production: {
     client: "pg",
     connection: dbConnection,
     pool: {
@@ -32,7 +17,22 @@ module.exports = {
       directory: "./data/seeds"
     }
   },
-  testing: { 
+  development: {
+    //pointing to our local postgres db
+    client: "pg",
+    connection: dbConnection,
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      directory: "./data/migrations"
+    },
+    seeds: {
+      directory: "./data/seeds"
+    }
+  },
+  testing: {
     client: "pg",
     connection: dbConnection,
     pool: {
@@ -46,4 +46,4 @@ module.exports = {
       directory: "./data/seeds"
     }
   }
-}
+};

--- a/routes/fatsecret/fatsecret.js
+++ b/routes/fatsecret/fatsecret.js
@@ -16,8 +16,8 @@ const transformFatSecretData = response => {
     food_data = response.data.food;
     serving_measures = food_data.servings.serving;
   } catch (err) {
-    console.log(err);
     res.status(500).json({
+      err: err,
       message: "Internal Server Error"
     });
   }
@@ -133,13 +133,17 @@ router.get("/fatsecret/get-food/:food_id", async (req, res) => {
         // UPSERT the fresh food into Foods table
         foods = await upsertFoods(fatsecretFoods);
       } catch (err) {
-        console.log(err);
-        res.status(500).json({ err: err, message: "Failed to get food data" });
+        res.status(500).json({
+          err: err,
+          message: "Failed to get food data"
+        });
       }
     }
   } catch (err) {
-    console.log(err);
-    res.status(500).json({ err: err, message: "Failed to get food data" });
+    res.status(500).json({
+      err: err,
+      message: "Failed to get food data"
+    });
   }
 
   res.send(foods);

--- a/routes/fatsecret/fatsecret.js
+++ b/routes/fatsecret/fatsecret.js
@@ -10,8 +10,17 @@ const { upsertFoods } = require("./upsertFoods.js");
 const router = express.Router();
 
 const transformFatSecretData = response => {
-  const food_data = response.data.food;
-  const serving_measures = food_data.servings.serving;
+  let food_data;
+  let serving_measures;
+  try {
+    food_data = response.data.food;
+    serving_measures = food_data.servings.serving;
+  } catch (err) {
+    console.log(err);
+    res.status(500).json({
+      message: "Internal Server Error"
+    });
+  }
 
   // denormalizes food data by repeating food id and name, for each serving id
   // 's' argument stands for the serving we're work with
@@ -124,11 +133,13 @@ router.get("/fatsecret/get-food/:food_id", async (req, res) => {
         // UPSERT the fresh food into Foods table
         foods = await upsertFoods(fatsecretFoods);
       } catch (err) {
+        console.log(err);
         res.status(500).json({ err: err, message: "Failed to get food data" });
       }
     }
   } catch (err) {
-    res.status(500).json({ message: "Failed to get food data" });
+    console.log(err);
+    res.status(500).json({ err: err, message: "Failed to get food data" });
   }
 
   res.send(foods);

--- a/routes/fatsecret/upsertFoods.js
+++ b/routes/fatsecret/upsertFoods.js
@@ -1,5 +1,10 @@
+require("dotenv").config();
+
 const pgp = require("pg-promise")();
+
+// const dbConnection = process.env.DATABASE_URL + "?ssl=true";
 const dbConnection = process.env.DATABASE_URL;
+console.log(dbConnection);
 
 const db = pgp(dbConnection);
 

--- a/routes/fatsecret/upsertFoods.js
+++ b/routes/fatsecret/upsertFoods.js
@@ -2,9 +2,7 @@ require("dotenv").config();
 
 const pgp = require("pg-promise")();
 
-// const dbConnection = process.env.DATABASE_URL + "?ssl=true";
 const dbConnection = process.env.DATABASE_URL;
-console.log(dbConnection);
 
 const db = pgp(dbConnection);
 


### PR DESCRIPTION
# Description

in repo:
- adds "production" environment handling
- adds more error messages in fatsecret endpoints
- adds "dotenv" config to "upsert" db code so that `pg-promise` knows which environment to use
- adds error handling for when fatsecret_food_id's are requested and fatsecret has zero data for them
- edits one of the seed values for `Foods` for larger breadth possible in testing

on heroku (already done; just FYI)
- added postgres as a heroku addon (seen here: https://dashboard.heroku.com/apps/nutri-journal/resources)
- added an environmental var inside heroku to say "production"
- ran a manual deploy of this branch, to test (since our backend isn't officially "live")
- ran: `knex migrate:latest`
- seeds are **_not currently present_** within production database

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

1. manually deployed branch to heroku
2. to test migration & seeds functionality, ran: 
    a. `knex migrate:latest;`
    b. `knex seed:run;`
3. successfully requested three fatsecret_food_id's to test the three possible states of a fatsecret_food_id within `Foods` table:
    a. 3433 (existing in `Foods`, and only 1 hour old)
    b. 4881 (existing in `Foods`, but 25 hours old)
    b. 4891 (existing in `Foods`, but 23 hours old)
    c. 4888 (not existing in `Foods`)
4. to test "migration rollback" functionality, and then to rerun the migration for production use
    a. `knex migrate:rollback;`
    a. `knex migrate:latest;`

note: all "`heroku run`" commands were executed using this interface:
https://dashboard.heroku.com/apps/nutri-journal?web-console=nutri-journal

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
